### PR TITLE
Use old-style exception syntax

### DIFF
--- a/Maelstrom.py
+++ b/Maelstrom.py
@@ -62,8 +62,8 @@ def Initialize(pGame):
     try:
         import BridgeUtils
         BridgeUtils.LoadBridge("SovereignBridge")
-    except Exception as e:
-        print("Error loading SovereignBridge: " + str(e))
+    except Exception, e:
+        print "Error loading SovereignBridge:", e
 
     # Set CanonTitanA as the player’s ship
     pSet = App.g_kSetManager.GetSet("bridge")
@@ -71,7 +71,7 @@ def Initialize(pGame):
         pPlayer = MissionLib.CreatePlayerShip("CanonTitanA", pSet, "player", None)
         if pPlayer is None:
             pPlayer = MissionLib.CreatePlayerShip("Constitution", pSet, "player", None)
-    except Exception as e:
+    except Exception, e:
         pPlayer = MissionLib.CreatePlayerShip("Constitution", pSet, "player", None)
 
     App.Game_SetPlayer(pPlayer)


### PR DESCRIPTION
## Summary
- Switch `except Exception as e` to classic `except Exception, e` style for compatibility.
- Convert `print("...")` to statement form `print "...", e`.

## Testing
- ⚠️ `python2 -m py_compile Maelstrom.py` *(command not found)*
- ❌ `python -m py_compile Maelstrom.py` *(SyntaxError: multiple exception types must be parenthesized)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b6f4a9883209e0847cc49e0a90f