### PR TITLE
Log bridge load errors with stack trace

### DIFF
--- a/Maelstrom.py
+++ b/Maelstrom.py
@@ -9,6 +9,7 @@
 ###############################################################################
 import App
 import MissionLib
+import traceback
 
 #
 # This is where you would put Game level module globals
@@ -63,7 +64,8 @@ def Initialize(pGame):
         import BridgeUtils
         BridgeUtils.LoadBridge("SovereignBridge")
     except Exception, e:
-        print "Error loading SovereignBridge:", e
+        App.CPyDebug(__name__).Print("Error loading SovereignBridge:")
+        traceback.print_exc()
 
     # Set CanonTitanA as the player’s ship
     pSet = App.g_kSetManager.GetSet("bridge")


### PR DESCRIPTION
## Summary
- log SovereignBridge load failures with `App.CPyDebug` and full stack trace
- import Python's `traceback` module for detailed error output

## Testing
- ⚠️ `python -m py_compile Maelstrom.py` (fails: SyntaxError due to Python 2 syntax with Python 3)
- ⚠️ `python2 -m py_compile Maelstrom.py` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bb1d7df71c8320882a9dc01659670d