### PR TITLE
Add debug output for player ship creation fallback

### DIFF
--- a/Maelstrom.py
+++ b/Maelstrom.py
@@ -9,6 +9,7 @@
 ###############################################################################
 import App
 import MissionLib
+import traceback
 
 #
 # This is where you would put Game level module globals
@@ -72,6 +73,8 @@ def Initialize(pGame):
         if pPlayer is None:
             pPlayer = MissionLib.CreatePlayerShip("Constitution", pSet, "player", None)
     except Exception, e:
+        App.CPyDebug(__name__).Print("CreatePlayerShip failed:")
+        traceback.print_exc()
         pPlayer = MissionLib.CreatePlayerShip("Constitution", pSet, "player", None)
 
     App.Game_SetPlayer(pPlayer)


### PR DESCRIPTION
## Summary
- add traceback import
- log error via CPyDebug and traceback when CreatePlayerShip fails

## Testing
- `python -m py_compile Maelstrom.py` *(fails: SyntaxError: multiple exception types must be parenthesized)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1e54784c8320adc1349f80761804